### PR TITLE
Added push command, updated build to allow parallel builds

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,10 +13,11 @@ declare module "docker-compose" {
     exec(container:String, command:String, options: IDockerComposeOptions): Promise<IDockerComposeResult>;
     logs(container:String, command:String, options: IDockerComposeLogOptions): Promise<IDockerComposeResult>;
     run(service:String, command:String, options: IDockerComposeOptions): Promise<IDockerComposeResult>;
-    buildAll(options: IDockerComposeOptions): Promise<IDockerComposeResult>;
-    buildMany(services:String[], options: IDockerComposeOptions): Promise<IDockerComposeResult>;
+    buildAll(options: IDockerComposeBuildOptions): Promise<IDockerComposeResult>;
+    buildMany(services:String[], options: IDockerComposeBuildOptions): Promise<IDockerComposeResult>;
     buildOne(service:String, options: IDockerComposeOptions): Promise<IDockerComposeResult>;
     ps(options: IDockerComposeOptions): Promise<IDockerComposeResult>;
+    push(options: IDockerComposePushOptions): Promise<IDockerComposeResult>;
   }
 
   interface IDockerComposeOptions {
@@ -25,8 +26,16 @@ declare module "docker-compose" {
     log?: boolean;
   }
 
-  interface IDockerComposeLogOptions extends IDockerComposeOptions{
+  interface IDockerComposeLogOptions extends IDockerComposeOptions {
     follow: boolean;
+  }
+
+  interface IDockerComposeBuildOptions extends IDockerComposeOptions {
+    parallel?: boolean;
+  }
+
+  interface IDockerComposePushOptions extends IDockerComposeOptions {
+    ignorePushFailures?: boolean;
   }
 
   interface IDockerComposeResult {

--- a/index.js
+++ b/index.js
@@ -182,13 +182,18 @@ const run = function (container, command, options) {
  * @param {object} options
  * @param {string} options.cwd
  * @param {boolean} [options.log]
+ * @param {?boolean} [options.parallel]
  * @param {?(string|string[])} [options.config]
  * @param {?object} [options.env]
  *
  * @return {object} std.out / std.err
  */
 const buildAll = function (options) {
-  return execCompose('build', [], options);
+  return execCompose(
+    'build',
+    options.parallel ? [ '--parallel' ] : [],
+    options,
+  );
 };
 
 /**
@@ -197,13 +202,18 @@ const buildAll = function (options) {
  * @param {object} options
  * @param {string} options.cwd
  * @param {boolean} [options.log]
+ * @param {?boolean} [options.parallel]
  * @param {?(string|string[])} [options.config]
  * @param {?object} [options.env]
  *
  * @return {object} std.out / std.err
  */
 const buildMany = function (services, options) {
-  return execCompose('build', services, options);
+  return execCompose(
+    'build',
+    options.parallel ? [ '--parallel' ].concat(services) : services,
+    options,
+  );
 };
 
 /**
@@ -231,6 +241,23 @@ const buildOne = function (service, options) {
  */
 const ps = function (options) {
   return execCompose('ps', [], options);
+};
+
+/**
+ * Push command
+ * @param {object} options
+ * @param {string} options.cwd
+ * @param {boolean} [options.log]
+ * @param {?boolean} options.ignorePushFailures
+ * @param {?(string|string[])} [options.config]
+ * @param {?object} [options.env]
+ */
+const push = function (options) {
+  return execCompose(
+    'push',
+    options.ignorePushFailures ? [ '--ignore-push-failures' ] : [],
+    options,
+  );
 };
 
 /**
@@ -287,4 +314,23 @@ const logs = function (service, options) {
   return execCompose('logs', args, options);
 };
 
-module.exports = { upAll, upMany, upOne, kill, down, stop, rm, exec, logs, restartAll, restartMany, restartOne, run, buildAll, buildMany, buildOne, ps };
+module.exports = {
+  upAll,
+  upMany,
+  upOne,
+  kill,
+  down,
+  stop,
+  rm,
+  exec,
+  logs,
+  restartAll,
+  restartMany,
+  restartOne,
+  run,
+  buildAll,
+  buildMany,
+  buildOne,
+  ps,
+  push,
+};


### PR DESCRIPTION
- Added the `push` command to allow to push docker-compose to local or remote registries
- Added `options.parallel` as an optional option for buildAll and buildMany to parallel-ize building multiple images.
- Update index.d.ts

I wasn't sure if/how to add tests for push without either having (1) a remote registry available to push to or (2) spinning up a local registry somehow but for now there's no changes to the tests.