### PR TITLE
Fix trailing commas causing syntax error on NodeJS 6.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ const buildAll = function (options) {
   return execCompose(
     'build',
     options.parallel ? [ '--parallel' ] : [],
-    options,
+    options
   );
 };
 
@@ -251,7 +251,7 @@ const buildMany = function (services, options) {
   return execCompose(
     'build',
     options.parallel ? [ '--parallel' ].concat(services) : services,
-    options,
+    options
   );
 };
 
@@ -343,7 +343,7 @@ const push = function (options) {
   return execCompose(
     'push',
     options.ignorePushFailures ? [ '--ignore-push-failures' ] : [],
-    options,
+    options
   );
 };
 


### PR DESCRIPTION
Resolves #66