### PR TITLE
[run/exec] allow user to pass array for command parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ const rm = function (options) {
  * @return {object} std.out / std.err
  */
 const exec = function (container, command, options) {
-  const args = command.split(/\s+/);
+  const args = Array.isArray(command) ? command : command.split(/\s+/);
 
   return execCompose('exec', [ '-T', container ].concat(args), options);
 };
@@ -210,7 +210,7 @@ const exec = function (container, command, options) {
  * @return {object} std.out / std.err
  */
 const run = function (container, command, options) {
-  const args = command.split(/\s+/);
+  const args = Array.isArray(command) ? command : command.split(/\s+/);
 
   return execCompose('run', [ '-T', container ].concat(args), options);
 };


### PR DESCRIPTION
Would make it possible to have a bit more control over the commands you run. Splitting on any space prevents me from making slightly more complex commands.

Small example:

```js
// no luck
compose.run('container1', 'echo hello world | base64');

// no luck
compose.run('container1', 'bin/bash -c "echo hello world | base64"');

// would work with these changes
compose.run('container1', [ '/bin/bash', '-c', 'echo hello world | base64' ]);
```

