### PR TITLE
Fix declaration for `logs` function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export declare function rm(options: IDockerComposeOptions): Promise<IDockerCompo
 
 export declare function exec(container: String, command: String, options: IDockerComposeOptions): Promise<IDockerComposeResult>;
 
-export declare function logs(container: String, command: String, options: IDockerComposeLogOptions): Promise<IDockerComposeResult>;
+export declare function logs(container: String, options: IDockerComposeLogOptions): Promise<IDockerComposeResult>;
 
 export declare function run(service: String, command: String, options: IDockerComposeOptions): Promise<IDockerComposeResult>;
 


### PR DESCRIPTION
Realized that declaration files for `logs` function requires 3 arguments instead of correct 2 when checking tests