### PR TITLE
BLD: add support for logging for multiple services

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export declare function rm(options: IDockerComposeOptions): Promise<IDockerCompo
 
 export declare function exec(container: String, command: String, options: IDockerComposeOptions): Promise<IDockerComposeResult>;
 
-export declare function logs(container: String, options: IDockerComposeLogOptions): Promise<IDockerComposeResult>;
+export declare function logs(services: String[], options: IDockerComposeLogOptions): Promise<IDockerComposeResult>;
 
 export declare function run(service: String, command: String, options: IDockerComposeOptions): Promise<IDockerComposeResult>;
 

--- a/index.js
+++ b/index.js
@@ -386,7 +386,7 @@ const restartOne = function (service, options) {
 };
 
 /**
- * @param {string} service
+ * @param {?(string|string[])} services
  * @param {object} options
  * @param {string} options.cwd
  * @param {boolean} [options.log]
@@ -395,8 +395,8 @@ const restartOne = function (service, options) {
  * @param {?object} [options.env]
  * @param {?(string[]|Array<string|string[]>)} [options.composeOptions]
  */
-const logs = function (service, options) {
-  let args = [ service ];
+const logs = function (services, options) {
+  let args = Array.isArray(services) ? services : [ services ];
 
   if (options.follow) {
     args = [ '--follow', ...args ];

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ npm install --save-dev docker-compose
 * `stop(options)` - Stop running containers without removing them
 * `rm(options)` - Remove stopped service containers - always uses the `-f` flag due to non interactive mode
 * `exec(container, command, options)` - Exec `command` inside `container`, uses `-T` to properly handle stdin & stdout
-* `logs(container, command, options)` - Show logs of service. Use `options.follow` `true|false` to turn on `--follow` flag.
+* `logs(services, options)` - Show logs of service(s). Use `options.follow` `true|false` to turn on `--follow` flag.
 * `run(service, command, options)` - Run a one-off `command` on a service, uses `-T` to properly handle stdin & stdout
 * `buildAll(options)` - Build or rebuild services
 * `buildMany(services, options)` - Build or rebuild services


### PR DESCRIPTION
Expands on #38 to add logging for multiple services simultaneously. One nice feature about `docker-compose` logs is that when launched simultaneously for multiple services, they are automatically color-coded. This feature is lost in the initial implementation found in #38 where one can only log one service at a time. This PR keeps the same interface but accounts for the fact that one can pass a single service or an array of services as a parameter, and the code will handle both cases providing the added benefit of automatic color-coding when passing an array of services.

Tested and working as expected.

Also corrected two minor typos from the previous PR referred above.