### PR TITLE
Fix TypeScript typings for DockerComposeResult

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ interface IDockerComposePushOptions extends IDockerComposeOptions {
 }
 
 interface IDockerComposeResult {
-    exitCode: ?number;
+    exitCode?: number;
     out: string;
     err: string;
 }


### PR DESCRIPTION
`fieldName: ?number` is not a valid type expression. I assume this was a mistake, but in any case it will fail in TypeScript projects with the error `JSDoc types can only be used inside documentation comments.`.