### PR TITLE
Fix linting issues after build, import proper es2015 lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest test --verbose",
-    "eslint": "./node_modules/.bin/eslint .",
+    "eslint": "eslint src/**/*.ts test/**/*.ts",
     "build": "tsc",
     "prepublishOnly": "tsc"
   },
@@ -42,7 +42,8 @@
       "name": "Sergey Falinsky"
     },
     {
-      "name": "Lars Kumbier"
+      "name": "Lars Kumbier",
+      "url": "https://kumbier.it"
     },
     {
       "name": "Paweł Niedzielski"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es2015"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
two minor changes to make the build more resilient:
* fix linting after build was called
* use proper es2015 library (for Promises, etc.) in tsconfig