### PR TITLE
Add a 'version' function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,3 +235,7 @@ export const port = function (service: string, containerPort: string | number, o
 
   return execCompose('port', args, options);
 };
+
+export const version = function (options?: IDockerComposeOptions): Promise<IDockerComposeResult> {
+  return execCompose('version', [ '--short' ], options);
+};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -490,3 +490,9 @@ test('returns the port for a started service', async (): Promise<void> => {
   expect(port.out).toMatch(/.*:[0-9]{1,5}/);
   await compose.down(config);
 });
+
+test('returns version information', async (): Promise<void> => {
+  const version = await compose.version();
+
+  expect(version.out).toBeTruthy();
+});


### PR DESCRIPTION
I'm working on some user-facing software that I want to be able to do a quick smoke test and make sure they're running Docker as a part of the app startup. I figured running version was the safest check, but was surprised to see there wasn't a way to do that yet with this library, so this is just a little add.

I figure it may also come in handy in the future if we require a certain version for a specific docker-compose feature, and need to ask the user to upgrade.