### PR TITLE
chore(deps): remove useless dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@types/node": "^12.6.2",
     "@typescript-eslint/eslint-plugin": "^1.12.0",
     "@typescript-eslint/parser": "^1.12.0",
-    "composefile": "^0.3.0",
     "dockerode": "^2.5.7",
     "eslint": "^5.6.0",
     "eslint-config-es": "^0.8.11",


### PR DESCRIPTION
**composefile** isn't needed for this package to work.