### PR TITLE
Update flags incompatible with detached mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ const execCompose = (command, args, options: IDockerComposeOptions = {}): Promis
 const shouldUseDefaultNonInteractiveFlag = function(options: IDockerComposeOptions = {}): boolean {
   const commandOptions = options.commandOptions || [];
   const containsOtherNonInteractiveFlag = commandOptions.reduce((memo: boolean, item: string | string[]) => {
-    return memo && !item.includes('--abort-on-container-exit');
+    return memo && !item.includes('--abort-on-container-exit') && !item.includes('--no-start');
   }, true);
   return containsOtherNonInteractiveFlag;
 };


### PR DESCRIPTION
The flag `--no-start` in the up command is also incompatible with `-d`

```bash
$ docker-compose up --no-start -d
ERROR: --no-start and --detach cannot be combined.
```