### PR TITLE
feat: allow to pass docker compose configuration as string

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
     },
     {
       "name": "Sebastián Balay"
+    },
+    {
+      "name": "Gabriel Fürstenheim",
+      "url": "https://github.com/furstenheim"
     }
   ],
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ compose.exec('node', 'npm install', { cwd: path.join(__dirname) })
 
 * `cwd {string}`: mandatory folder path to the `docker-compose.yml`
 * `config {(string|string[])}`: custom and/or multiple yml files can be specified (relative to `cwd`)
+* `configAsString {string}`: configuration can be provided as is, instead of relying on a file. In case `configAsString` is provided `config` will be ignored.
 * `[log] {boolean}`:  optional setting to enable console logging (output of `docker-compose` `stdout`/`stderr` output)
 * `[composeOptions] string[]|Array<string|string[]`: pass optional compose options like `"--verbose"` or `[["--verbose"], ["--log-level", "DEBUG"]]` or `["--verbose", ["--loglevel", "DEBUG"]]` for *all* commands.
 * `[commandOptions] string[]|Array<string|string[]`: pass optional command options like `"--build"` or `[["--build"], ["--timeout", "5"]]` or `["--build", ["--timeout", "5"]]` for the `up` command. Viable `commandOptions` depend on the command (`up`, `down` etc.) itself

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -303,7 +303,7 @@ test('ensure run and exec with command defined as array are working', async (): 
 });
 
 test('build accepts config as string', async (): Promise<void> => {
-  const configuration = await new Promise<string>(function (resolve, reject) {
+  const configuration = await new Promise<string>(function (resolve, reject): void {
     readFile(path.join(__dirname, 'docker-compose-2.yml'), function (err, content) {
       if (err) {
         reject(err);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -303,17 +303,18 @@ test('ensure run and exec with command defined as array are working', async (): 
 });
 
 test('build accepts config as string', async (): Promise<void> => {
-  const configuration = await new Promise(function (resolve, reject) {
+  const configuration = await new Promise<string>(function (resolve, reject) {
     readFile(path.join(__dirname, 'docker-compose-2.yml'), function (err, content) {
       if (err) {
-        return reject(err);
+        reject(err);
+        return;
       }
-      return resolve(content.toString());
+      resolve(content.toString());
     })
   });
   const config = {
-    configAsString: <string> configuration,
-    log: logOutput
+    configAsString: configuration,
+    log: logOutput,
   };
 
   await compose.upAll(config);


### PR DESCRIPTION
Addresses this issue: https://github.com/PDMLab/docker-compose/issues/109

Probably not properly linted because of https://github.com/PDMLab/docker-compose/issues/123