### PR TITLE
Fix broken build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - run: yarn lint
   build:
     runs-on: ubuntu-18.04
-    name: Test
+    name: Build + Test
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,5 @@ jobs:
       with:
         node-version: '12'
     - run: yarn
+    - run: yarn build
     - run: yarn test

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,9 +769,9 @@
     "@types/serve-static" "*"
 
 "@types/fs-extra@^9.0.9":
-  version "9.0.10"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.10.tgz#8023a72e3d06cf54929ea47ec7634e47f33f4046"
-  integrity sha512-O9T2LLkRDiTlalOBdjEkcnT0MRdT2+wglCl7pJUJ3mkWkR8hX4K+5bg2raQNJcLv4V8zGuTXe7Ud3wSqkTyuyQ==
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.11.tgz#8cc99e103499eab9f347dbc6ca4e99fb8d2c2b87"
+  integrity sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
```
❯ yarn build
yarn run v1.22.5
$ tsc
node_modules/@types/fs-extra/index.d.ts:243:49 - error TS2694: Namespace '"fs"' has no exported member 'RmOptions'.

243 export function rm(path: PathLike, options?: fs.RmOptions): Promise<void>;
                                                    ~~~~~~~~~


Found 1 error.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```