### PR TITLE
feat: single container pause and unpause added

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -273,6 +273,20 @@ export const stopOne = function (
   return execCompose('stop', [service], options)
 }
 
+export const pauseOne = function (
+  service: string,
+  options?: IDockerComposeOptions
+): Promise<IDockerComposeResult> {
+  return execCompose('pause', [service], options)
+}
+
+export const unpauseOne = function (
+  service: string,
+  options?: IDockerComposeOptions
+): Promise<IDockerComposeResult> {
+  return execCompose('unpause', [service], options)
+}
+
 export const kill = function (
   options?: IDockerComposeOptions
 ): Promise<IDockerComposeResult> {
@@ -497,6 +511,8 @@ export default {
   down,
   stop,
   stopOne,
+  pauseOne,
+  unpauseOne,
   kill,
   rm,
   exec,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -232,12 +232,13 @@ test('ensure only single container gets paused then resumed', async (): Promise<
   await compose.pauseOne('proxy', opts)
   expect(await isContainerRunning('/compose_test_web')).toBeTruthy()
   expect(await isContainerRunning('/compose_test_proxy')).toBeTruthy()
+  let errMsg
   try {
     await compose.exec('proxy', 'cat /etc/os-release', opts)
-    fail('Container was not paused')
-  } catch(err) {
-    expect(err.err).toContain('is paused')
+  } catch (err) {
+    errMsg = err.err
   }
+  expect(errMsg).toContain('is paused')
   await compose.unpauseOne('proxy', opts)
   expect(await isContainerRunning('/compose_test_web')).toBeTruthy()
   expect(await isContainerRunning('/compose_test_proxy')).toBeTruthy()


### PR DESCRIPTION
closes #174
This PR adds functionality to pause (`.pauseOne`) and un-pause (`.unpauseOne`) a single container.  The method used is very similar to the existing `.stopOne` function. 
A new test has been incorporated which stops the proxy container and then attempts a `cat /etc/os-release` command.  This should fail because the container is paused, with an error that state the container is paused.  The test then un-pauses the container and checks that the same command now succeeds.
The ability to (un)pause a container is useful for testing whether an application can re-synchronise after missing some incoming data.