### PR TITLE
Fix skipping first container in ps command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export const mapPsOutput = (output: string): DockerComposePsResult => {
   const services = output
     .split(`\n`)
     .filter(nonEmptyString)
-    .filter((_, index) => index > 1)
+    .filter((_, index) => index > 0)
     .map((line) => {
       const [
         nameFragment,


### PR DESCRIPTION
When using docker-compose, it always skips the first container (because indexes are zero based).