### PR TITLE
Fix ps quiet trim on undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,19 +78,33 @@ export type DockerComposePsResult = {
   }>
 }
 
-export const mapPsOutput = (output: string): DockerComposePsResult => {
+export const mapPsOutput = (
+  output: string,
+  options?: IDockerComposeOptions
+): DockerComposePsResult => {
+  let isQuiet = false
+  if (options?.commandOptions) {
+    isQuiet =
+      options.commandOptions.includes('-q') ||
+      options.commandOptions.includes('--quiet')
+  }
   const services = output
     .split(`\n`)
     .filter(nonEmptyString)
-    .filter((_, index) => index > 1)
+    .filter((_, index) => isQuiet || index > 1)
     .map((line) => {
-      const [
-        nameFragment,
-        commandFragment,
-        stateFragment,
-        untypedPortsFragment
-      ] = line.split(/\s{3,}/)
-
+      let nameFragment = line
+      let commandFragment = ''
+      let stateFragment = ''
+      let untypedPortsFragment = ''
+      if (!isQuiet) {
+        ;[
+          nameFragment,
+          commandFragment,
+          stateFragment,
+          untypedPortsFragment
+        ] = line.split(/\s{3,}/)
+      }
       return {
         name: nameFragment.trim(),
         command: commandFragment.trim(),
@@ -417,7 +431,7 @@ export const ps = async function (
 ): Promise<TypedDockerComposeResult<DockerComposePsResult>> {
   try {
     const result = await execCompose('ps', [], options)
-    const data = mapPsOutput(result.out)
+    const data = mapPsOutput(result.out, options)
     return {
       ...result,
       data

--- a/src/index.ts
+++ b/src/index.ts
@@ -511,7 +511,7 @@ export const version = async function (
 ): Promise<TypedDockerComposeResult<DockerComposeVersionResult>> {
   try {
     const result = await execCompose('version', ['--short'], options)
-    const version = result.out.replace('\n', '')
+    const version = result.out.replace('\n', '').trim()
     return {
       ...result,
       data: { version }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -554,7 +554,7 @@ test('config show data for docker-compose files (services)', async (): Promise<v
   })
 
   expect(std.data.services.length).toBe(5)
-  expect(std.data.services[0]).toBe('build_test_1')
+  expect(std.data.services[0]).toContain('build_test_1')
   expect(std.err).toBeFalsy()
 })
 
@@ -566,7 +566,7 @@ test('config show data for docker-compose files (volumes)', async (): Promise<vo
   })
 
   expect(std.data.volumes.length).toBe(1)
-  expect(std.data.volumes[0]).toBe('db-data')
+  expect(std.data.volumes[0]).toContain('db-data')
   expect(std.err).toBeFalsy()
 })
 
@@ -722,6 +722,32 @@ test('parse ps output', () => {
       }
     ]
   })
+})
+
+test('ps output when quiet', () => {
+  const output = `64848fc721dfeff435edc7d4bb42e2f0e0a10d0c7602b73729a7fd7b09b7586f
+aed60ce17575e69c56cc4cb07eeba89b5d7b7b2b307c8b87f3363db6af850719
+f49548fa0b1f88846b78c65c6ea7f802bcbdfb2cf10204497eb89ba622d7715b
+`
+  const psOut = mapPsOutput(output, { commandOptions: ['-q'] })
+
+  expect(psOut.services[0]).toEqual(
+    expect.objectContaining({
+      name: '64848fc721dfeff435edc7d4bb42e2f0e0a10d0c7602b73729a7fd7b09b7586f'
+    })
+  )
+
+  expect(psOut.services[1]).toEqual(
+    expect.objectContaining({
+      name: 'aed60ce17575e69c56cc4cb07eeba89b5d7b7b2b307c8b87f3363db6af850719'
+    })
+  )
+
+  expect(psOut.services[2]).toEqual(
+    expect.objectContaining({
+      name: 'f49548fa0b1f88846b78c65c6ea7f802bcbdfb2cf10204497eb89ba622d7715b'
+    })
+  )
 })
 
 test('ensure progress callback is called', async (): Promise<void> => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -684,7 +684,7 @@ test('removes container', async (): Promise<void> => {
 })
 
 test('returns version information', async (): Promise<void> => {
-  const version = await (await compose.version()).data.version
+  const version = (await compose.version()).data.version
 
   expect(version).toMatch(/^(\d+\.)?(\d+\.)?(\*|\d+)$/)
 })
@@ -724,7 +724,7 @@ test('parse ps output', () => {
   })
 })
 
-test('ps output when quiet', () => {
+test('ps returns container ids when quiet', () => {
   const output = `64848fc721dfeff435edc7d4bb42e2f0e0a10d0c7602b73729a7fd7b09b7586f
 aed60ce17575e69c56cc4cb07eeba89b5d7b7b2b307c8b87f3363db6af850719
 f49548fa0b1f88846b78c65c6ea7f802bcbdfb2cf10204497eb89ba622d7715b


### PR DESCRIPTION
Adding support for `commandsOptions: [ '-q']` (or `--quiet`) for ps.
Adding tests.

Adding fix for tests that failed on Windows.