### PR TITLE
ci: use github runner on ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - master
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: Lint
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,16 @@ on:
     branches:
       - master
 jobs:
+  info:
+    runs-on: ubuntu-22.04
+    name: info
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - run: docker-compose --version
+      - run: node --version
   lint:
     runs-on: ubuntu-22.04
     name: Lint
@@ -19,7 +29,7 @@ jobs:
     - run: yarn
     - run: yarn lint
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: Build + Test
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
this will also upgrade `docker-compose` v1 to `1.29.2`