### PR TITLE
docs: added upMany and upOne methods to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ The documentation can be found [here](https://pdmlab.github.io/docker-compose/).
 
 ## Example
 
-To start service containers based on the `docker-compose.yml` file in your current directory, just call `compose.up` like this:
+To start service containers based on the `docker-compose.yml` file in your current directory, just call `compose.upAll` like this:
 
 ```javascript
 compose.upAll({ cwd: path.join(__dirname), log: true }).then(
@@ -30,6 +30,20 @@ compose.upAll({ cwd: path.join(__dirname), log: true }).then(
     console.log('something went wrong:', err.message)
   }
 )
+```
+
+Start specific services using `compose.upMany`:
+
+```javascript
+const services = ['serviceA', 'serviceB']
+compose.upMany(services, { cwd: path.join(__dirname), log: true })
+```
+
+Or start a single service with `compose.upOne`:
+
+```javascript
+const service = 'serviceA'
+compose.upOne(service, { cwd: path.join(__dirname), log: true })
 ```
 
 To execute command inside a running container


### PR DESCRIPTION
I wanted to start only few services from my docker compose file.
The main readme didn't have any information about upMany and upOne commands, so I had to check the source code.
