### PR TITLE
Remove unnecessary console.log in v2 api

### DIFF
--- a/src/v2.ts
+++ b/src/v2.ts
@@ -217,7 +217,6 @@ export const execCompose = (
 
     childProc.on('exit', (exitCode): void => {
       result.exitCode = exitCode
-      console.log(`exiting command ${command}`)
       setTimeout(() => {
         if (exitCode === 0) {
           resolve(result)


### PR DESCRIPTION
In the v2 api there is a `console.log` making it hard to integrate in own applications.