### PR TITLE
feat: ps supports json format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,26 @@ To execute command inside a running container
 compose.exec('node', 'npm install', { cwd: path.join(__dirname) })
 ```
 
+To list the containers for a compose project
+
+```javascript
+const result = await compose.ps({ cwd: path.join(__dirname) })
+result.data.services.forEach((service) => {
+  console.log(service.name, service.command, service.state, service.ports)
+  // state is e.g. 'Up 2 hours'
+})
+```
+
+The docker-compose v2 version also support the `--format json` command option to get a better state support:
+
+```javascript
+const result = await compose.ps({ cwd: path.join(__dirname), commandOptions: [["--format", "json"]] })
+result.data.services.forEach((service) => {
+  console.log(service.name, service.command, service.state, service.ports)
+  // state is one of the defined states: paused | restarting | removing | running | dead | created | exited
+})
+```
+
 ## Known issues with v2 support
 
 * During testing we noticed that `docker compose` seems to send it's exit code also commands don't seem to have finished. This doesn't occur for all commands, but for example with `stop` or `down`. We had the option to wait for stopped / removed containers using third party libraries but this would make bootstrapping `docker-compose` much more complicated for the users. So we decided to use a `setTimeout(500)` workaround. We're aware this is not perfect but it seems to be the most appropriate solution for now. Details can be found in the [v2 PR discussion](https://github.com/PDMLab/docker-compose/pull/228#issuecomment-1422895821) (we're happy to get help here).

--- a/test/v2/compose.test.ts
+++ b/test/v2/compose.test.ts
@@ -691,7 +691,35 @@ describe('when calling ps command', (): void => {
     const web = std.data.services.find(
       (service) => service.name === 'compose_test_web'
     )
+    expect(web?.command).toContain('nginx') // Note: actually it contains "nginx -g 'daemon off;'"
+    expect(web?.state).toContain('Up')
+    expect(web?.ports.length).toBe(2)
+    expect(web?.ports[1].exposed.port).toBe(443)
+    expect(web?.ports[1].exposed.protocol).toBe('tcp')
+    expect(web?.ports[1].mapped?.port).toBe(443)
+    expect(web?.ports[1].mapped?.address).toBe('0.0.0.0')
+    await compose.down({ cwd: path.join(__dirname), log: logOutput })
+  })
+
+  it('ps shows status data for started containers using json format', async (): Promise<void> => {
+    await compose.upAll({ cwd: path.join(__dirname), log: logOutput })
+    // await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    const std = await compose.ps({
+      cwd: path.join(__dirname),
+      log: logOutput,
+      commandOptions: [['--format', 'json']]
+    })
+
+    const running = await getRunningContainers()
+
+    expect(std.err).toBeFalsy()
     expect(std.data.services.length).toBe(2)
+    const web = std.data.services.find(
+      (service) => service.name === 'compose_test_web'
+    )
+    expect(web?.command).toContain('nginx') // Note: actually it contains "nginx -g 'daemon off;'"
+    expect(web?.state).toBe('running')
     expect(web?.ports.length).toBe(2)
     expect(web?.ports[1].exposed.port).toBe(443)
     expect(web?.ports[1].exposed.protocol).toBe('tcp')


### PR DESCRIPTION
This pull requests adds support for `--format json` so that the output can be more consistent concerning the state.
In addition it exports the single `DockerComposePsResultService` as type 

Notes:
- local tests do not work for me (neither before nor after I started the modifications)
- the `state` from the plain text ps output is probably not correct: a typical output is `Up 3 hours` but should be `running`. I did not try to correct this.