### PR TITLE
More flexibility in process creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,14 @@ import childProcess from 'child_process'
 import yaml from 'yaml'
 import mapPorts from './map-ports'
 
+export interface IDockerComposeExecutableOptions {
+  executablePath: string,
+  options?: string[] | (string | string[])[]
+}
+
 export interface IDockerComposeOptions {
   cwd?: string
-  executablePath?: string
+  executable?: IDockerComposeExecutableOptions
   config?: string | string[]
   configAsString?: string
   log?: boolean
@@ -178,9 +183,12 @@ export const execCompose = (
 
     const cwd = options.cwd
     const env = options.env || undefined
-    const executablePath = options.executablePath || 'docker-compose'
+    const executable = options.executable || {executablePath: 'docker-compose'}
 
-    const childProc = childProcess.spawn(executablePath, composeArgs, {
+    const executableOptions executable.options || []
+    const executableArgs = composeOptionsToArgs(executableOptions)
+
+    const childProc = childProcess.spawn(executable.executablePath, executableArgs.concat(composeArgs), {
       cwd,
       env
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import yaml from 'yaml'
 import mapPorts from './map-ports'
 
 export interface IDockerComposeExecutableOptions {
-  executablePath: string,
+  executablePath: string
   options?: string[] | (string | string[])[]
 }
 
@@ -183,15 +183,21 @@ export const execCompose = (
 
     const cwd = options.cwd
     const env = options.env || undefined
-    const executable = options.executable || {executablePath: 'docker-compose'}
+    const executable = options.executable || {
+      executablePath: 'docker-compose'
+    }
 
-    const executableOptions executable.options || []
+    const executableOptions = executable.options || []
     const executableArgs = composeOptionsToArgs(executableOptions)
 
-    const childProc = childProcess.spawn(executable.executablePath, executableArgs.concat(composeArgs), {
-      cwd,
-      env
-    })
+    const childProc = childProcess.spawn(
+      executable.executablePath,
+      executableArgs.concat(composeArgs),
+      {
+        cwd,
+        env
+      }
+    )
 
     childProc.on('error', (err): void => {
       reject(err)

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -3,7 +3,7 @@ import yaml from 'yaml'
 import mapPorts from './v2-map-ports'
 
 export interface IDockerComposeExecutableOptions {
-  executablePath: string,
+  executablePath: string
   options?: string[] | (string | string[])[]
 }
 
@@ -210,9 +210,9 @@ export const execCompose = (
 
     const cwd = options.cwd
     const env = options.env || undefined
-    const executable = options.executable || {executablePath: "docker"}
+    const executable = options.executable || { executablePath: 'docker' }
 
-    const executableOptions executable.options || []
+    const executableOptions = executable.options || []
     const executableArgs = composeOptionsToArgs(executableOptions)
 
     const childProc = childProcess.spawn(

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -2,9 +2,14 @@ import childProcess from 'child_process'
 import yaml from 'yaml'
 import mapPorts from './v2-map-ports'
 
+export interface IDockerComposeExecutableOptions {
+  executablePath: string,
+  options?: string[] | (string | string[])[]
+}
+
 export interface IDockerComposeOptions {
   cwd?: string
-  executablePath?: string
+  executable?: IDockerComposeExecutableOptions
   config?: string | string[]
   configAsString?: string
   log?: boolean
@@ -205,11 +210,14 @@ export const execCompose = (
 
     const cwd = options.cwd
     const env = options.env || undefined
-    const executablePath = options.executablePath || 'docker'
+    const executable = options.executable || {executablePath: "docker"}
+
+    const executableOptions executable.options || []
+    const executableArgs = composeOptionsToArgs(executableOptions)
 
     const childProc = childProcess.spawn(
-      executablePath,
-      ['compose', ...composeArgs],
+      executable.executablePath,
+      [...executableArgs, 'compose', ...composeArgs],
       {
         cwd,
         env


### PR DESCRIPTION
My project needs the flexebility to run docker inside of wsl for that i run docker as `wsl docker compose ...`
Now this is possible by running for example:

```javascript
compose.upAll({
   executable: {
      executablePath: "wsl",
      options: ["docker"]
   }
})
```