### PR TITLE
Add `options` parameter to `stats` function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -707,12 +707,13 @@ export const version = async function (
 }
 
 export const stats = async function (
-  service: string
+  service: string,
+  options?: IDockerComposeOptions
 ): Promise<DockerComposeStatsResult> {
   const args = ['--no-stream', '--format', '"{{ json . }}"', service]
 
   try {
-    const result = await execCompose('stats', args)
+    const result = await execCompose('stats', args, options)
     // Remove first and last quote from output, as well as newline.
     const output = result.out.replace('\n', '').trim().slice(1, -1)
     return JSON.parse(output)


### PR DESCRIPTION
Small oversight on my side when I created #285. I forgot the optional `options`  parameter, which I now added in this PR.

Especially useful in my case to be able to pass the `cwd` option.