### PR TITLE
feat: add --timestamps to log option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export type DockerComposeConfigVolumesResult = {
 
 export interface IDockerComposeLogOptions extends IDockerComposeOptions {
   follow?: boolean
+  timestamps?: boolean
 }
 
 export interface IDockerComposeBuildOptions extends IDockerComposeOptions {
@@ -675,10 +676,13 @@ export const logs = function (
   services: string | string[],
   options: IDockerComposeLogOptions = {}
 ): Promise<IDockerComposeResult> {
-  let args = Array.isArray(services) ? services : [services]
+  const args = Array.isArray(services) ? services : [services]
 
   if (options.follow) {
-    args = ['--follow', ...args]
+    args.unshift('--follow')
+  }
+  if (options.timestamps) {
+    args.unshift('--timestamps')
   }
 
   return execCompose('logs', args, options)

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -890,6 +890,18 @@ describe('logs command', (): void => {
     expect(std.out.includes('compose_test_proxy')).toBeTruthy()
     await compose.downAll({ cwd: path.join(__dirname), log: logOutput })
   })
+
+  it('does include timestamps', async (): Promise<void> => {
+    await compose.upAll({ cwd: path.join(__dirname), log: logOutput })
+    const std = await compose.logs('proxy', {
+      cwd: path.join(__dirname),
+      log: logOutput,
+      timestamps: true
+    })
+
+    expect(std.out.includes('compose_test_proxy')).toBeTruthy()
+    await compose.downAll({ cwd: path.join(__dirname), log: logOutput })
+  })
 })
 
 describe('port command', (): void => {

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -899,7 +899,8 @@ describe('logs command', (): void => {
       timestamps: true
     })
 
-    expect(std.out.includes('compose_test_proxy')).toBeTruthy()
+    const currentDate = new Date().toISOString().slice(0, 10)
+    expect(std.out.includes(currentDate)).toBeTruthy()
     await compose.downAll({ cwd: path.join(__dirname), log: logOutput })
   })
 })


### PR DESCRIPTION
closes #301 

Please note: tests are failing for me locally on `master`, but I did run the logs tests with `describe.only` and they pass. So failures seem to be unrelated to my changes...

My env is ubuntu 24.04 and:
```
Docker version 28.3.3, build 980b856
Docker Compose version v2.39.1
node --version -> v22.17.1
```